### PR TITLE
fix: set the cwd for chokidar when watching files

### DIFF
--- a/src/support/docs.js
+++ b/src/support/docs.js
@@ -173,6 +173,7 @@ module.exports = ({
             const docsWatcher = chokidar
                 .watch(`${source}/**`, {
                     ignoreInitial: true,
+                    cwd: process.cwd(),
                 })
                 .on('all', (e, p) =>
                     reporter.print(
@@ -194,6 +195,7 @@ module.exports = ({
                 chokidar
                     .watch(jsdoc, {
                         ignoreInitial: true,
+                        cwd: process.cwd(),
                     })
                     .on('all', async (e, p) => {
                         reporter.print(

--- a/src/support/docs.js
+++ b/src/support/docs.js
@@ -165,7 +165,7 @@ module.exports = ({
             }
 
             if (jsdoc && jsdoc.length) {
-                processJSDoc()
+                await processJSDoc()
             }
         },
 


### PR DESCRIPTION
Ran into an error where I got errors when passing in `--jsdoc ./src`. When I changed to `src/` it worked, which lead me to believe that there was a problem with the current working directory when watching files.

Adding the `cwd` option with the current working directory from the process fixes the problem.

```
varl@veronika:~/dev/dhis2/libs/ui-core$ npx d2-utils-docsite serve ./docs -o ./build/docs --jsdoc ./src --jsdoc-output-file api.md
Initializing docsite...
Building...
Serving docsite at http://localhost:3000
Watching for changes...
(node:9786) UnhandledPromiseRejectionWarning: TypeError: Expected pattern to be a non-empty string
    at picomatch (/home/varl/dev/dhis2/libs/ui-core/node_modules/picomatch/lib/picomatch.js:43:11)
    at createPattern (/home/varl/dev/dhis2/libs/ui-core/node_modules/@dhis2/cli-utils-docsite/node_modules/anymatch/index.js:27:18)
    at mtchers.map.matcher (/home/varl/dev/dhis2/libs/ui-core/node_modules/@dhis2/cli-utils-docsite/node_modules/anymatch/index.js:89:43)
    at Array.map (<anonymous>)
    at anymatch (/home/varl/dev/dhis2/libs/ui-core/node_modules/@dhis2/cli-utils-docsite/node_modules/anymatch/index.js:89:28)
    at parts.every (/home/varl/dev/dhis2/libs/ui-core/node_modules/@dhis2/cli-utils-docsite/node_modules/chokidar/index.js:214:51)
    at Array.every (<anonymous>)
    at unmatchedGlob.dirParts.some (/home/varl/dev/dhis2/libs/ui-core/node_modules/@dhis2/cli-utils-docsite/node_modules/chokidar/index.js:21
:22)
    at Array.some (<anonymous>)
    at WatchHelper.filterDir (/home/varl/dev/dhis2/libs/ui-core/node_modules/@dhis2/cli-utils-docsite/node_modules/chokidar/index.js:211:43)
(node:9786) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async functi
n without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:9786) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled
will terminate the Node.js process with a non-zero exit code.
```

This also adds the `await` keyword for the build step for consistency.