### PR TITLE
feat(jsdoc2md): allow d2.config.js configuration

### DIFF
--- a/src/support/docs.js
+++ b/src/support/docs.js
@@ -113,6 +113,7 @@ module.exports = ({
         configFile,
         packageJsonFile: path.join(process.cwd(), 'package.json'),
     })
+
     data.sourcedir = data.sourcedir
         ? path.join(data.sourcedir, path.relative(process.cwd(), source))
         : path.relative(process.cwd(), source)
@@ -126,7 +127,7 @@ module.exports = ({
     }
 
     const processJSDoc = async () => {
-        await JSDocEngine.render(jsdoc, jsdocOut, data)
+        await JSDocEngine.render(jsdoc, jsdocOut, data.docsite.jsdoc2md)
     }
 
     const processOnDeleted = async p => {

--- a/src/support/docs.js
+++ b/src/support/docs.js
@@ -56,7 +56,6 @@ const loadData = ({ dataInput, configFile, packageJsonFile }) => {
         configData = {
             ...config,
             ...config.docsite,
-            ...config.js2docmd,
         }
         reporter.debug(`Template data loaded from config file ${configFile}`)
     } catch (e) {
@@ -72,7 +71,6 @@ const loadData = ({ dataInput, configFile, packageJsonFile }) => {
             repo: parsePackageRepository(pkg.repository),
             ...pkg.d2,
             ...(pkg.d2 && pkg.d2.docsite),
-            ...(pkg.d2 && pkg.d2.jsdoc2md),
         }
         reporter.debug(
             `Template data loaded from package.json file ${packageJsonFile}`
@@ -128,7 +126,7 @@ module.exports = ({
     }
 
     const processJSDoc = async () => {
-        await JSDocEngine.render(jsdoc, jsdocOut, data.jsdoc2md)
+        await JSDocEngine.render(jsdoc, jsdocOut, data)
     }
 
     const processOnDeleted = async p => {

--- a/src/support/docs.js
+++ b/src/support/docs.js
@@ -128,7 +128,7 @@ module.exports = ({
     }
 
     const processJSDoc = async () => {
-        await JSDocEngine.render(jsdoc, jsdocOut, data)
+        await JSDocEngine.render(jsdoc, jsdocOut, data.jsdoc2md)
     }
 
     const processOnDeleted = async p => {

--- a/src/support/docs.js
+++ b/src/support/docs.js
@@ -56,6 +56,7 @@ const loadData = ({ dataInput, configFile, packageJsonFile }) => {
         configData = {
             ...config,
             ...config.docsite,
+            ...config.js2docmd,
         }
         reporter.debug(`Template data loaded from config file ${configFile}`)
     } catch (e) {
@@ -71,6 +72,7 @@ const loadData = ({ dataInput, configFile, packageJsonFile }) => {
             repo: parsePackageRepository(pkg.repository),
             ...pkg.d2,
             ...(pkg.d2 && pkg.d2.docsite),
+            ...(pkg.d2 && pkg.d2.jsdoc2md),
         }
         reporter.debug(
             `Template data loaded from package.json file ${packageJsonFile}`
@@ -126,7 +128,7 @@ module.exports = ({
     }
 
     const processJSDoc = async () => {
-        await JSDocEngine.render(jsdoc, jsdocOut)
+        await JSDocEngine.render(jsdoc, jsdocOut, data)
     }
 
     const processOnDeleted = async p => {

--- a/src/support/jsdoc.js
+++ b/src/support/jsdoc.js
@@ -26,7 +26,7 @@ const render = async (source, dest, options) => {
 
     const markdown = await jsdoc2md.render({
         ...defaults,
-        ...options,
+        ...options.docsite.jsdoc2md,
     })
 
     await fs.writeFile(dest, markdown)

--- a/src/support/jsdoc.js
+++ b/src/support/jsdoc.js
@@ -3,7 +3,7 @@ const jsdoc2md = require('jsdoc-to-markdown')
 const fs = require('fs-extra')
 const path = require('path')
 
-const render = async (source, dest, opts) => {
+const render = async (source, dest, options) => {
     let files = Array.isArray(source) ? source : [source]
     files = files.map(f =>
         fs.statSync(f).isDirectory() ? path.join(f, '/**/*') : f
@@ -26,7 +26,7 @@ const render = async (source, dest, opts) => {
 
     const markdown = await jsdoc2md.render({
         ...defaults,
-        ...opts.jsdoc2md,
+        ...options,
     })
 
     await fs.writeFile(dest, markdown)

--- a/src/support/jsdoc.js
+++ b/src/support/jsdoc.js
@@ -3,7 +3,7 @@ const jsdoc2md = require('jsdoc-to-markdown')
 const fs = require('fs-extra')
 const path = require('path')
 
-const render = async (source, dest) => {
+const render = async (source, dest, opts) => {
     let files = Array.isArray(source) ? source : [source]
     files = files.map(f =>
         fs.statSync(f).isDirectory() ? path.join(f, '/**/*') : f
@@ -15,12 +15,18 @@ const render = async (source, dest) => {
         )}`,
         files
     )
-    const markdown = await jsdoc2md.render({
+
+    const defaults = {
         files,
         'heading-depth': 2,
         'example-lang': 'jsx',
         'param-format': 'code',
         'global-index-format': 'list',
+    }
+
+    const markdown = await jsdoc2md.render({
+        ...defaults,
+        ...opts.jsdoc2md,
     })
 
     await fs.writeFile(dest, markdown)

--- a/src/support/jsdoc.js
+++ b/src/support/jsdoc.js
@@ -26,7 +26,7 @@ const render = async (source, dest, options) => {
 
     const markdown = await jsdoc2md.render({
         ...defaults,
-        ...options.docsite.jsdoc2md,
+        ...options,
     })
 
     await fs.writeFile(dest, markdown)


### PR DESCRIPTION
jsdoc2md can now be configured with the supported options[1] in the same
vein as docsify.

[1] https://github.com/jsdoc2md/jsdoc-to-markdown/blob/master/docs/API.md#jsdoc2mdrenderoptions--promise