### PR TITLE
feat: update CLI link in navbar

### DIFF
--- a/template/markdown/_navbar.md
+++ b/template/markdown/_navbar.md
@@ -1,3 +1,3 @@
--   [CLI](https://github.com/dhis2/cli)
+-   [CLI](https://cli.dhis2.nu)
 -   [Platform](https://platform.dhis2.nu)
 -   [Runtime](https://runtime.dhis2.nu)


### PR DESCRIPTION
@varl this should do it once `https://cli.dhis2.nu` is published