### PR TITLE
fix: do not compile storybook links

### DIFF
--- a/template/js/initDocsify.js
+++ b/template/js/initDocsify.js
@@ -17,6 +17,7 @@ window.$docsify = {
     maxLevel: 1,
     auto2top: true,
     externalLinkTarget: '_self',
+    noCompileLinks: ['/demo/.*'],
 
     pagination: {
         crossChapter: true,


### PR DESCRIPTION
As @paschalidi noticed, the links from our api docs to the storybook components don't work. Docsify is interpreting the links as links within the docsify documentation, but it should be interpreting them as regular links.

This excludes any links that matches the supplied regex from docsify's internal routing.

docs: https://docsify.js.org/#/configuration?id=nocompilelinks