### PR TITLE
chore: remove node 10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "engines": {
-        "node": ">=10"
+        "node": ">=12"
     },
     "dependencies": {
         "@dhis2/cli-helpers-engine": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
         "node": ">=12"
     },
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "^1.5.0",
-        "@dhis2/cli-helpers-template": "^1.0.2",
+        "@dhis2/cli-helpers-engine": "^3.0.0",
+        "@dhis2/cli-helpers-template": "^3.0.0",
         "chokidar": "^3.3.1",
         "front-matter": "^3.1.0",
         "fs-extra": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,15 +261,30 @@
     update-notifier "^3.0.0"
     yargs "^13.1.0"
 
-"@dhis2/cli-helpers-template@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-template/-/cli-helpers-template-1.0.2.tgz#537904af58f0965e67a5b490fb2737c148ff24d0"
-  integrity sha512-kXSgK0MqeyIpOemJf2fJNQzjcpbW3IvESeICguvVo0wmChFz1i4EaXEG18NI0hhrICilqk2ci8sizkBP+fMV/A==
+"@dhis2/cli-helpers-engine@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-engine/-/cli-helpers-engine-3.0.0.tgz#dacddea16de7e5e60280aefbee2e5661795b78b3"
+  integrity sha512-e8cZFFsunQp56iLx1FKBWGZ1tmWOjdbqJaBwOnzvsKPyYopV9RzNcPm+HIBwfnCjHBWoWTf6ijaf3xVnimZC2w==
+  dependencies:
+    chalk "^3.0.0"
+    cross-spawn "^7.0.3"
+    find-up "^5.0.0"
+    fs-extra "^8.0.1"
+    inquirer "^7.3.3"
+    request "^2.88.0"
+    tar "^4.4.8"
+    update-notifier "^3.0.0"
+    yargs "^13.1.0"
+
+"@dhis2/cli-helpers-template@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-template/-/cli-helpers-template-3.0.0.tgz#1cfb625a6e1a6a824386bd0cfd3ba646783920c3"
+  integrity sha512-CPjXG3By9uf2dNb1DsziAuwTPM125QbTMGY9t9J97hBhpy7Y1xnChaoXAxhpdOEHKENwbox6blYKf1GrWeFAkw==
   dependencies:
     "@dhis2/cli-helpers-engine" "^1.5.0"
     fs-extra "^8.1.0"
-    handlebars "^4.5.3"
-    isbinaryfile "^4.0.2"
+    handlebars "^4.7.3"
+    isbinaryfile "^4.0.4"
 
 "@dhis2/cli-style@^7.2.1":
   version "7.2.1"
@@ -2214,6 +2229,18 @@ handlebars@^4.5.3:
   optionalDependencies:
     uglify-js "^3.1.4"
 
+handlebars@^4.7.3:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -2709,10 +2736,10 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isbinaryfile@^4.0.2:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.6.tgz#edcb62b224e2b4710830b67498c8e4e5a4d2610b"
-  integrity sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==
+isbinaryfile@^4.0.4:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.8.tgz#5d34b94865bd4946633ecc78a026fc76c5b11fcf"
+  integrity sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==
 
 isexe@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
BREAKING CHANGE: New minimum version for NodeJS is 12.x.
