### PR TITLE
feat: add react docgen source links

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,16 @@
         "live-server": "^1.2.1",
         "marked": "^2.1.3",
         "match-all": "^1.2.5",
-        "react-docgen": "^5.4.0"
+        "react-docgen": "^5.4.0",
+        "url-join": "^4.0.1"
     },
     "scripts": {
         "build": "./bin/d2-utils-docsite build ./docs -o dist --jsdoc src/ --jsdocOutputFile api.md",
         "serve": "./bin/d2-utils-docsite serve ./docs -o dist --jsdoc src/ --jsdocOutputFile api.md",
-        "docgen-test-ui": "./bin/d2-utils-docsite build ./docs -o dist --reactDocs ../ui/components/**/src --reactDocsOutputFile ui-test.md --debug",
-        "docgen-serve-ui": "./bin/d2-utils-docsite serve ./docs -o dist --reactDocs ../ui/components/**/src --reactDocsOutputFile ui-test.md --debug",
-        "docgen-build-playground": "./bin/d2-utils-docsite build ./docs -o dist --reactDocs ../../dhis2-playground/docgen-testing/src --reactDocsOutputFile ui-test.md --debug",
-        "docgen-serve-playground": "./bin/d2-utils-docsite serve ./docs -o dist --reactDocs ../../dhis2-playground/docgen-testing/src --reactDocsOutputFile ui-test.md --debug",
+        "docgen-test-ui": "./bin/d2-utils-docsite build ./docs -o dist --reactDocs ../ui/components/**/src --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../ui",
+        "docgen-serve-ui": "./bin/d2-utils-docsite serve ./docs -o dist --reactDocs ../ui/components/**/src --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../ui",
+        "docgen-build-playground": "./bin/d2-utils-docsite build ./docs -o dist --reactDocs ../../dhis2-playground/docgen-testing/src --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../../dhis2-playground/docgen-testing",
+        "docgen-serve-playground": "./bin/d2-utils-docsite serve ./docs -o dist --reactDocs ../../dhis2-playground/docgen-testing/src --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../../dhis2-playground/docgen-testing",
         "lint": "d2-style check",
         "format": "d2-style apply"
     },

--- a/src/support/commonOptions.js
+++ b/src/support/commonOptions.js
@@ -15,6 +15,8 @@ module.exports.resolvePath
  * @param {string} jsdocOutputFile=jsdoc.md - The path, relative to `dest`, in which to write the `jsdoc` output
  * @param {string} reactDocs - One or more arrays of paths (or globs) to parse with React Docgen
  * @param {string} reactDocsOutputFile=react-api.md - The path, relative to `dest`, in which to write the React docs output
+ * @param {boolean} reactDocsLinkSource=false - If set, component filepaths in the generated markdown will link to that file on GitHub based on the `repository` field of `package.json`. **NOTE:** If this script is not being run in the root of the repository, use the `localRepoRoot` argument
+ * @param {string} localRepoRoot=. - Relative path to the root of the repository. Required for source code links if this script is not being run in the repo root
  */
 module.exports = {
     dest: {
@@ -61,5 +63,17 @@ module.exports = {
         description:
             'The output path, relative to dest, for the generated React Docgen markdown file',
         default: 'react-api.md',
+    },
+    reactDocsLinkSource: {
+        type: 'boolean',
+        description:
+            'Add links to component source files according to the repository field in package.json',
+        default: 'false',
+    },
+    localRepoRoot: {
+        type: 'string',
+        description:
+            'Relative path to the root of the repository. Required for source code links if this script is not being run in the repo root',
+        default: '.',
     },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,6 +5276,11 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
+
 url-parse-lax@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"


### PR DESCRIPTION
Links to components' source code on GitHub using package.json `repository` field, the component filepaths, and the path to the repository root locally if necessary