### PR TITLE
feat: handle imported/exported components

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "scripts": {
         "build": "./bin/d2-utils-docsite build ./docs -o dist --jsdoc src/ --jsdocOutputFile api.md",
         "serve": "./bin/d2-utils-docsite serve ./docs -o dist --jsdoc src/ --jsdocOutputFile api.md",
-        "docgen-test-ui": "./bin/d2-utils-docsite build ./docs -o dist --reactDocs ../ui/components/**/src --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../ui",
-        "docgen-serve-ui": "./bin/d2-utils-docsite serve ./docs -o dist --reactDocs ../ui/components/**/src --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../ui",
-        "docgen-build-playground": "./bin/d2-utils-docsite build ./docs -o dist --reactDocs ../../dhis2-playground/docgen-testing/src --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../../dhis2-playground/docgen-testing",
-        "docgen-serve-playground": "./bin/d2-utils-docsite serve ./docs -o dist --reactDocs ../../dhis2-playground/docgen-testing/src --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../../dhis2-playground/docgen-testing",
+        "docgen-test-ui": "./bin/d2-utils-docsite build ./docs -o dist --reactDocs ../ui/components/**/src/index.js --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../ui",
+        "docgen-serve-ui": "./bin/d2-utils-docsite serve ./docs -o dist --reactDocs ../ui/components/**/src/index.js --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../ui",
+        "docgen-build-playground": "./bin/d2-utils-docsite build ./docs -o dist --reactDocs ../../dhis2-playground/docgen-testing/src/index.js --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../../dhis2-playground/docgen-testing",
+        "docgen-serve-playground": "./bin/d2-utils-docsite serve ./docs -o dist --reactDocs ../../dhis2-playground/docgen-testing/src/index.js --reactDocsOutputFile ui-test.md --reactDocsLinkSource --localRepoRoot ../../dhis2-playground/docgen-testing",
         "lint": "d2-style check",
         "format": "d2-style apply"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "live-server": "^1.2.1",
         "marked": "^2.1.3",
         "match-all": "^1.2.5",
-        "react-docgen": "^5.4.0",
+        "react-docgen": "^6.0.0-alpha.0",
         "url-join": "^4.0.1"
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "@dhis2/cli-helpers-engine": "^3.0.0",
         "@dhis2/cli-helpers-template": "^3.0.0",
+        "ast-types": "^0.14.2",
         "chokidar": "^3.3.1",
         "front-matter": "^3.1.0",
         "fs-extra": "^8.1.0",

--- a/src/support/commonOptions.js
+++ b/src/support/commonOptions.js
@@ -13,7 +13,7 @@ module.exports.resolvePath
  * @param {string} changelogFile=./CHANGELOG.md - Path to changelog source file
  * @param {string} jsdoc - One or more arrays of paths (or globs) to search for `jsdoc` comments
  * @param {string} jsdocOutputFile=jsdoc.md - The path, relative to `dest`, in which to write the `jsdoc` output
- * @param {string} reactDocs - One or more arrays of paths (or globs) to parse with React Docgen
+ * @param {string} reactDocs - One or more paths or globs to entrypoint(s) to parse with React Docgen. Docs for components exported from these files will be generated
  * @param {string} reactDocsOutputFile=react-api.md - The path, relative to `dest`, in which to write the React docs output
  * @param {boolean} reactDocsLinkSource=false - If set, component filepaths in the generated markdown will link to that file on GitHub based on the `repository` field of `package.json`. **NOTE:** If this script is not being run in the root of the repository, use the `localRepoRoot` argument
  * @param {string} localRepoRoot=. - Relative path to the root of the repository. Required for source code links if this script is not being run in the repo root
@@ -55,13 +55,14 @@ module.exports = {
     },
     reactDocs: {
         type: 'array',
-        description: 'The path glob(s) to parse with React Docgen',
+        description:
+            'One or more paths or globs to package entrypoint(s) to parse with React Docgen; usually `index.js` file(s)',
         normalize: false,
     },
     reactDocsOutputFile: {
         type: 'string',
         description:
-            'The output path, relative to dest, for the generated React Docgen markdown file',
+            'The output path, relative to dest, for the markdown file generated from React Docgen docs',
         default: 'react-api.md',
     },
     reactDocsLinkSource: {

--- a/src/support/react-docs/custom-resolver.js
+++ b/src/support/react-docs/custom-resolver.js
@@ -1,0 +1,144 @@
+/**
+ * This is is a custom resolver for React Docgen. Resolvers receive an AST
+ * from a parsed file and return an array NodePaths that correspond to
+ * component definitions.
+ *
+ * React Docgen provides an optional `findAllExportedComponentDefinitions`
+ * resolver, which can handle some exported components since the 6.0.0-alpha
+ * version of docgen, but doesn't support the `export { Component } from './Component.js'`
+ * export syntax. This custom one uses the same logic as the built-in one, and
+ * adds support for that export syntax.
+ */
+
+const { namedTypes: t, visit } = require('ast-types')
+const reactDocgen = require('react-docgen')
+const resolveExportSpecifier = require('./resolve-export-specifier.js')
+const resolveHOC = require('./resolveHOC.js')
+
+const {
+    isExportsOrModuleAssignment,
+    isReactComponentClass,
+    isReactCreateClassCall,
+    isReactForwardRefCall,
+    isStatelessComponent,
+    normalizeClassDefinition,
+    resolveExportDeclaration,
+    resolveToValue,
+    // resolveHOC, // not exported from library; copied locally
+} = reactDocgen.utils
+
+function ignore() {
+    return false
+}
+
+function isComponentDefinition(path, importer) {
+    return (
+        isReactCreateClassCall(path, importer) ||
+        isReactComponentClass(path, importer) ||
+        isStatelessComponent(path, importer) ||
+        isReactForwardRefCall(path, importer)
+    )
+}
+
+function resolveDefinition(definition, importer) {
+    if (isReactCreateClassCall(definition, importer)) {
+        // return argument
+        const resolvedPath = resolveToValue(
+            definition.get('arguments', 0),
+            importer
+        )
+        if (t.ObjectExpression.check(resolvedPath.node)) {
+            return resolvedPath
+        }
+    } else if (isReactComponentClass(definition, importer)) {
+        normalizeClassDefinition(definition)
+        return definition
+    } else if (
+        isStatelessComponent(definition, importer) ||
+        isReactForwardRefCall(definition, importer)
+    ) {
+        return definition
+    }
+    return null
+}
+
+function findExportedComponentDefinitionsUsingImporter(ast, parser, importer) {
+    const components = []
+    function exportDeclaration(path) {
+        const definitions = resolveExportDeclaration(path, importer)
+            // resolve export specifiers the above function missed:
+            .map(path => resolveExportSpecifier(path, importer))
+            .reduce((acc, definition) => {
+                if (isComponentDefinition(definition, importer)) {
+                    acc.push(definition)
+                } else {
+                    const resolved = resolveToValue(
+                        resolveHOC(definition, importer),
+                        importer
+                    )
+                    if (isComponentDefinition(resolved, importer)) {
+                        acc.push(resolved)
+                    }
+                }
+                return acc
+            }, [])
+            .map(definition => resolveDefinition(definition, importer))
+
+        if (definitions.length === 0) {
+            return false
+        }
+        definitions.forEach(definition => {
+            if (definition && components.indexOf(definition) === -1) {
+                components.push(definition)
+            }
+        })
+        return false
+    }
+
+    visit(ast, {
+        visitFunctionDeclaration: ignore,
+        visitFunctionExpression: ignore,
+        visitClassDeclaration: ignore,
+        visitClassExpression: ignore,
+        visitIfStatement: ignore,
+        visitWithStatement: ignore,
+        visitSwitchStatement: ignore,
+        visitCatchCause: ignore,
+        visitWhileStatement: ignore,
+        visitDoWhileStatement: ignore,
+        visitForStatement: ignore,
+        visitForInStatement: ignore,
+
+        visitExportDeclaration: exportDeclaration,
+        visitExportNamedDeclaration: exportDeclaration,
+        visitExportDefaultDeclaration: exportDeclaration,
+        // todo: handle ExportAll
+        visitExportAllDeclaration: exportDeclaration,
+
+        visitAssignmentExpression: function (path) {
+            // Ignore anything that is not `exports.X = ...;` or
+            // `module.exports = ...;`
+            if (!isExportsOrModuleAssignment(path, importer)) {
+                return false
+            }
+            // Resolve the value of the right hand side. It should resolve to a call
+            // expression, something like React.createClass
+            path = resolveToValue(path.get('right'), importer)
+            if (!isComponentDefinition(path, importer)) {
+                path = resolveToValue(resolveHOC(path, importer), importer)
+                if (!isComponentDefinition(path, importer)) {
+                    return false
+                }
+            }
+            const definition = resolveDefinition(path, importer)
+            if (definition && components.indexOf(definition) === -1) {
+                components.push(definition)
+            }
+            return false
+        },
+    })
+
+    return components
+}
+
+module.exports = findExportedComponentDefinitionsUsingImporter

--- a/src/support/react-docs/filepath-handler.js
+++ b/src/support/react-docs/filepath-handler.js
@@ -1,0 +1,24 @@
+const { namedTypes: t } = require('ast-types')
+
+// The React Docgen parser adds an 'options' object to the root Program node
+// for each component's NodePath, which has a 'filename' property (which is
+// actually a filepath). This function retrieves the 'options' object from
+// a component's root Program node
+function getOptions(path) {
+    while (!t.Program.check(path.node)) {
+        path = path.parentPath
+    }
+
+    return path.node.options || {}
+}
+
+// Receives a documentation object and a NodePath for a component definition,
+// and retrieves component's filepath and adds it to the documentation object
+function filepathHandler(documentation, path) {
+    const options = getOptions(path)
+    if (options.filename) {
+        documentation.set('filepath', options.filename)
+    }
+}
+
+module.exports = filepathHandler

--- a/src/support/react-docs/resolve-export-specifier.js
+++ b/src/support/react-docs/resolve-export-specifier.js
@@ -1,0 +1,31 @@
+/**
+ * The `resolveExportDeclaration` util used in the custom resolver doesn't
+ * handle exports using the syntax `export {Component} from './Component.js'`.
+ *
+ * This helper catches those exports and uses the FS importer to resolve them
+ * to a component definition (NodePath).
+ */
+
+const { namedTypes: t } = require('ast-types')
+const resolveToValue = require('react-docgen').utils.resolveToValue
+
+module.exports = function resolveExportSpecifier(path, importer) {
+    const parentPath = path.parent
+    if (t.ExportSpecifier.check(parentPath.node)) {
+        let exportName
+
+        if (t.ImportDefaultSpecifier.check(parentPath.node)) {
+            exportName = 'default'
+        } else {
+            exportName = parentPath.node.local.name
+        }
+
+        const resolvedPath = importer(parentPath.parentPath, exportName)
+
+        if (resolvedPath) {
+            return resolveToValue(resolvedPath, importer)
+        }
+    }
+
+    return path
+}

--- a/src/support/react-docs/resolveHOC.js
+++ b/src/support/react-docs/resolveHOC.js
@@ -1,0 +1,53 @@
+/**
+ * This is a React Docgen util that is probably supposed to be exported from
+ * the library like the other utils, but is not (probably unintentionally).
+ *
+ * It's copied here to complete the custom resolver.
+ */
+
+const { namedTypes: t } = require('ast-types')
+const reactDocgen = require('react-docgen')
+
+const { isReactCreateClassCall, isReactForwardRefCall, resolveToValue } =
+    reactDocgen.utils
+
+/*
+ * If the path is a call expression, it recursively resolves to the
+ * rightmost argument, stopping if it finds a React.createClass call expression
+ *
+ * Else the path itself is returned.
+ */
+module.exports = function resolveHOC(path, importer) {
+    const node = path.node
+    if (
+        t.CallExpression.check(node) &&
+        !isReactCreateClassCall(path, importer) &&
+        !isReactForwardRefCall(path, importer)
+    ) {
+        if (node.arguments.length) {
+            const inner = path.get('arguments', 0)
+
+            // If the first argument is one of these types then the component might be the last argument
+            // If there are all identifiers then we cannot figure out exactly and have to assume it is the first
+            if (
+                node.arguments.length > 1 &&
+                (t.Literal.check(inner.node) ||
+                    t.ObjectExpression.check(inner.node) ||
+                    t.ArrayExpression.check(inner.node) ||
+                    t.SpreadElement.check(inner.node))
+            ) {
+                return resolveHOC(
+                    resolveToValue(
+                        path.get('arguments', node.arguments.length - 1),
+                        importer
+                    ),
+                    importer
+                )
+            }
+
+            return resolveHOC(resolveToValue(inner, importer), importer)
+        }
+    }
+
+    return path
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4119,10 +4119,10 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-docgen@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.4.0.tgz#2cd7236720ec2769252ef0421f23250b39a153a1"
-  integrity sha512-JBjVQ9cahmNlfjMGxWUxJg919xBBKAoy3hgDgKERbR+BcF4ANpDuzWAScC7j27hZfd8sJNmMPOLWo9+vB/XJEQ==
+react-docgen@^6.0.0-alpha.0:
+  version "6.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-6.0.0-alpha.0.tgz#62bbedb63e5cf43e13957dc84cd9d7c3a4acb2ed"
+  integrity sha512-x04mIC8H6sLypv0bA87WW5hKmJXXM48aHaw5XD44LHcb+IqF3eL1Ev0YtXzxb7BXCoXV/WzpzCTuaqjUA39dyw==
   dependencies:
     "@babel/core" "^7.7.5"
     "@babel/generator" "^7.12.11"
@@ -4133,6 +4133,7 @@ react-docgen@^5.4.0:
     estree-to-babel "^3.1.0"
     neo-async "^2.6.1"
     node-dir "^0.1.10"
+    resolve "^1.17.0"
     strip-indent "^3.0.0"
 
 react-is@^16.8.1:


### PR DESCRIPTION
Updates the CLI to only generate docs for components that are exported from a library

Instead of specifying one or more directories to parse all JS files for component definitions, you can specify one or more package *entrypoints* that export components. For the UI library, this might look like `./components/**/src/index.js`. This script will find the definitions of all those exported components and generate docs for them.

The current React Docgen alpha version includes an [importer](https://github.com/reactjs/react-docgen/pull/464) that resolves imported types and values, which can be used to traverse imports to find exported component definitions. Tools that are built in to React Docgen already support parsing some exported components, but only when they use this syntax:
```js
import { Component } from './Component.js'
export { Component }
```
Most of the exports in the UI library are in this syntax though, which is not currently handled in React Docgen:
```js
export { Component } from './Component.js'
```

I added a custom resolver for React Docgen to use when resolving component definitions that handles that latter syntax.

I also added a custom handler that adds each component's filepath to its documentation object.

SIDE NOTE: I noticed in the UI library that there are a few components whose display names don't match their exported names - I propose that we make sure those match for documentation purposes and for clarity when inspecting a component tree. These are what I noticed:
1. `CenteredContent`: display name = `Center`
2. `ComponentCover`: display name = `Cover`
3. Table elements in `DataTable` (`TableBody`, `TableFoot`, `TableHead`, and `TableToolbar`): exported as `DataTable___`, but display name = `Table___`
    * I realize these aren't as straightforward to name, and they [might become the basic table components](https://github.com/dhis2/notes/discussions/297#discussioncomment-1147973) anyway. I think it's okay to give them the `DataTable_` display names until then, though


