### PR TITLE
fix: use <h2> for component names to make them searchable

### DIFF
--- a/src/support/react-docs/react-docs.js
+++ b/src/support/react-docs/react-docs.js
@@ -25,7 +25,7 @@ function getMarkdownFromDocgen(docgenDocs, options) {
         sourceURL = urlJoin(remoteRepoURL, relativeFilepath)
     }
 
-    const displayName = `### ${docgenDocs.displayName}`
+    const displayName = `## ${docgenDocs.displayName}`
     const filepath = linkSource
         ? `[**${relativeFilepath}**](${sourceURL})`
         : `**${relativeFilepath}**`


### PR DESCRIPTION
By default, the docsify search plugin only indexes `h1` and `h2` headings. 