### PR TITLE
feat: have both docs-name and page-name in title

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dhis2/cli-utils-docsite",
     "description": "Generate and serve standardized DHIS2 developer documentation",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "bin": {
         "d2-utils-docsite": "./bin/d2-utils-docsite"
     },

--- a/template/js/initDocsify.js
+++ b/template/js/initDocsify.js
@@ -26,6 +26,14 @@ window.$docsify = {
     },
 
     plugins: [
+        function (hook) {
+            hook.doneEach(function () {
+                // Invoked each time after the data is fully loaded, no arguments,
+                if (document.title !== '{{{name}}}') {
+                    document.title += ' - {{{name}}}'
+                }
+            })
+        },
         EditOnGithubPlugin.create(
             '{{{repo}}}/blob/master/{{{sourcedir}}}',
             undefined,


### PR DESCRIPTION
This makes the title have both the documentation site name and the page name in the browser's title.

So instead of having `use a stable version` on this page: https://cli.dhis2.nu/#/recipes/stable, you'd now get `use a stable version - DHIS2 CLI`. 